### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/content.js
+++ b/content.js
@@ -181,15 +181,21 @@ function isDownloadLink(link) {
   }
 
   // Fourth check: GitLab-specific patterns
-  if (href.includes("gitlab.com")) {
-    // GitLab archive downloads
-    if (pathname.includes("/-/archive/")) {
-      return true;
+  const allowedGitLabHosts = ["gitlab.com"];
+  try {
+    const parsedUrl = new URL(href);
+    if (allowedGitLabHosts.includes(parsedUrl.host)) {
+      // GitLab archive downloads
+      if (pathname.includes("/-/archive/")) {
+        return true;
+      }
+      // GitLab release downloads
+      if (pathname.includes("/-/releases/") && pathname.includes("/downloads/")) {
+        return true;
+      }
     }
-    // GitLab release downloads
-    if (pathname.includes("/-/releases/") && pathname.includes("/downloads/")) {
-      return true;
-    }
+  } catch (e) {
+    console.error("Invalid URL:", href, e);
   }
 
   // Fifth check: Hugging Face file downloads


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/Xget-for-Chrome/security/code-scanning/3](https://github.com/xixu-me/Xget-for-Chrome/security/code-scanning/3)

To fix the issue, the code should parse the URL using a library like `url` or `URL` (native in Node.js) and verify the host explicitly. This ensures that the check is performed on the actual host of the URL, rather than relying on substring matching. The fix involves replacing `href.includes("gitlab.com")` with a check that parses the URL and compares its host against a whitelist of allowed hosts.

Steps to implement the fix:
1. Parse the `href` using the `URL` constructor to extract the host.
2. Define a whitelist of allowed hosts (e.g., `["gitlab.com"]`).
3. Check if the parsed host is in the whitelist before proceeding with further checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
