### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*" # Triggers on version tags like v1.0.0, v1.2.3, etc.
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/Xget-for-Chrome/security/code-scanning/1](https://github.com/xixu-me/Xget-for-Chrome/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow, the following permissions are needed:
- `contents: read` for reading repository files.
- `contents: write` for creating releases and updating files.
- `packages: write` for publishing packages to the Chrome Web Store and Microsoft Edge Add-ons.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
